### PR TITLE
fix error not be return

### DIFF
--- a/client.go
+++ b/client.go
@@ -225,7 +225,8 @@ func (mb *client) readArea(area int, dbNumber int, start int, amount int, wordLe
 		address = address >> 8
 		request.Data[28] = byte(address & 0x0FF)
 
-		response, err := mb.send(&request)
+		var response *ProtocolDataUnit
+		response, err = mb.send(&request)
 		if err == nil {
 			if size := len(response.Data); size < 25 {
 				err = fmt.Errorf(ErrorText(errIsoInvalidDataSize)+"'%v'", len(response.Data))


### PR DESCRIPTION
func ErrorTest() (err error) {
	{
		err := errors.New("i am error test")
		if err != nil {
			fmt.Println(err)
			return //err is shadowed during return
		}

	}
	return
}