### PR TITLE
Add Go version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Overview
 -------------------
 Since years, there are tons of driver/connector in both commercial and open source that support connect to S7 family PLC devices. GoS7 is just simple missing pieces in S7 protocol which implementing in with pure Go(aka golang) with a strongly faith that low-level communication would be impelement by low-level programming language which proximity to binary and memory. 
 
+The minimum supported go version is 1.13.
+
 Functions
 -------------------
 AG:


### PR DESCRIPTION
Add version information for faster problem resolution. Binary digits are supported starting with Go 1.13.
https://github.com/robinson/gos7/blob/3bdf41f9a21cc0935c21aa3822e09feb68740fed/helper.go#L195
