### PR TITLE
fix: connection leaks

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -48,6 +48,7 @@ func NewTCPClientHandler(address string, rack int, slot int) *TCPClientHandler {
 	h.setConnectionParameters(address, 0x0100, remoteTSAP)
 	return h
 }
+
 // NewTCPClientHandlerWithConnectType allocates a new TCPClientHandler with connection type.
 func NewTCPClientHandlerWithConnectType(address string, rack int, slot int, connectType int) *TCPClientHandler {
 	h := &TCPClientHandler{}
@@ -59,12 +60,14 @@ func NewTCPClientHandlerWithConnectType(address string, rack int, slot int, conn
 	h.setConnectionParameters(address, 0x0100, remoteTSAP)
 	return h
 }
-//TCPClient creator for a TCP client with address, rack and slot, implement from interface client
+
+// TCPClient creator for a TCP client with address, rack and slot, implement from interface client
 func TCPClient(address string, rack int, slot int) Client {
 	handler := NewTCPClientHandler(address, rack, slot)
 	return NewClient(handler)
 }
-//TCPClientWithConnectType creator for a TCP client with address, rack, slot and connect type, implement from interface client
+
+// TCPClientWithConnectType creator for a TCP client with address, rack, slot and connect type, implement from interface client
 func TCPClientWithConnectType(address string, rack int, slot int, connectType int) Client {
 	handler := NewTCPClientHandlerWithConnectType(address, rack, slot, connectType)
 	return NewClient(handler)
@@ -196,6 +199,9 @@ func (mb *tcpTransporter) tcpConnect() error {
 		dialer := net.Dialer{Timeout: mb.Timeout}
 		conn, err := dialer.Dial("tcp", mb.Address)
 		if err != nil {
+			if conn != nil {
+				_ = conn.Close()
+			}
 			return err
 		}
 		mb.conn = conn
@@ -211,6 +217,9 @@ func (mb *tcpTransporter) connect() error {
 	//second stage: ISOTCP (ISO 8073) Connection
 	err = mb.isoConnect()
 	if err != nil {
+		if mb.conn != nil {
+			_ = mb.conn.Close()
+		}
 		return err
 	}
 	// Third stage : S7 protocol data unit negotiation
@@ -322,7 +331,7 @@ func (mb *tcpTransporter) closeIdle() {
 	}
 }
 
-//reserve for future use, need to verify the request and response
+// reserve for future use, need to verify the request and response
 func (mb *tcpPackager) Verify(request []byte, response []byte) (err error) {
 	return
 }


### PR DESCRIPTION
Fixing connection leaks: In some cases, even when a connection fails, it remains open. The reason for this behavior is unclear.
Sorry, some auto-formatted code was included in the submission.